### PR TITLE
Add the keytransparency android library

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,5 @@
+# Optional: GOPATH and ANDROID_HOME need to be passed to the bazel build command. 
+# To avoid typing them in the command line, please edit and uncomment the following lines.
+# build --action_env=ANDROID_HOME=/Your/Android/Home/Path # example:/Users/YourUserName/Library/Android/sdk
+# build --action_env=GOPATH=/Your/Go/Path/ # example: /Users/YourUserName/go
+

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,14 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# AndroidStudio files
+*.iml
+.gradle
+/local.properties
+/.idea/workspace.xml
+/.idea/libraries
+.DS_Store
+/build
+/captures
+.externalNativeBuild

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ hs_err_pid*
 /build
 /captures
 .externalNativeBuild
+
+# Bazel output files
+bazel-*

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,3 +9,4 @@
 # Names should be added to this file as:
 #     Name <email address>
 
+Antonio Marcedone <a.marcedone@gmail.com>

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,6 @@
+android_sdk_repository(
+    name = "androidsdk",
+    path = "/Users/antonio.marcedone/Library/Android/sdk",
+    api_level = 25,
+    build_tools_version = "25.0.0"
+)

--- a/keytransparency/BUILD
+++ b/keytransparency/BUILD
@@ -1,0 +1,28 @@
+android_library(
+  name = "keytransparency",
+  visibility = ["//visibility:public"],
+  srcs = ["src/main/java/com/google/keytransparency/KeyTransparencyException.java",
+          "src/main/java/com/google/keytransparency/KTClient.java"],
+  custom_package = "com.google.keytransparency",
+  manifest = "src/main/AndroidManifest.xml",
+  resource_files = glob(["src/main/res/**"]),
+  deps = [":gobind_keytransparency_android"],
+)
+
+aar_import(
+        name = "gobind_keytransparency_android",
+        aar = "keytransparency_gobind.aar",
+    )
+
+genrule(
+    name = "gobind_keytransparency_android_gen_aar",
+    srcs = [
+       # "//some:files",  # a filegroup with multiple files in it ==> $(locations)
+       # "//other:gen",   # a genrule with a single output ==> $(location)
+    ],
+    outs = ["keytransparency_gobind.aar"],
+    tags=["local"],
+    cmd = "gomobile bind -target android -o $@ -javapkg com.google.keytransparency.gobind github.com/google/keytransparency/core/client/gobindClient", # github.com/google/keytransparency/core/client/kt github.com/google/keytransparency/core/crypto/commitments",
+)
+
+

--- a/keytransparency/src/main/AndroidManifest.xml
+++ b/keytransparency/src/main/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+
+    package="com.google.keytransparency">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application android:allowBackup="true" android:label="@string/app_name"
+        android:supportsRtl="true">
+
+    </application>
+
+</manifest>

--- a/keytransparency/src/main/java/com/google/keytransparency/KTClient.java
+++ b/keytransparency/src/main/java/com/google/keytransparency/KTClient.java
@@ -1,0 +1,84 @@
+package com.google.keytransparency;
+
+import android.content.Context;
+import android.util.Log;
+import android.widget.TextView;
+
+import com.google.keytransparency.gobind.gobindClient.BClientParams;
+import com.google.keytransparency.gobind.gobindClient.GobindClient;
+import com.google.keytransparency.gobind.gobindClient.BWriter;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+
+public class KTClient {
+    private static final String TAG_LOGS_FROM_GOBIND = "KTGo:";
+
+    private final BClientParams clientParams;
+
+    // TODO remove me
+    TextView tv;
+    public void setTextViewForLogs(TextView tv) {
+        this.tv = tv;
+    }
+
+
+    public KTClient(String ktUrl, long mapID, byte[] ktServerTLSCert, byte[] vrfPubKey, byte[] ktSmrPubKey, byte[] trLogKey) {
+        clientParams = new BClientParams(ktUrl, mapID, ktServerTLSCert, vrfPubKey, ktSmrPubKey, trLogKey);
+        GobindClient.bSetCustomLogger(new WriterForGoLogs());
+    }
+
+    public KTClient(String ktUrl, long mapID, Context context, int ktServerTLSCertResID, int vrfPubKeyResID, int ktSmrPubKeyResID, int trLogKeyResID) throws IOException {
+        this(ktUrl, mapID, resourceToByteArray(context, ktServerTLSCertResID),
+                resourceToByteArray(context, vrfPubKeyResID),
+                resourceToByteArray(context, ktSmrPubKeyResID),
+                resourceToByteArray(context, trLogKeyResID));
+    }
+
+    public byte[] getEntry(String userName, String appName, int timeoutInMilliseconds) throws KeyTransparencyException {
+        try {
+            // TODO(amarcedone): do we want to store the latest smr so that it can be used for consistency of new requests?
+            return GobindClient.bGetEntry(timeoutInMilliseconds, clientParams, userName, appName);
+        } catch (Exception e) {
+            throw new KeyTransparencyException(e);
+        }
+    }
+
+//    byte[] verifyGetEntryResponse(){
+//        return null;
+//    }
+
+    private class WriterForGoLogs implements BWriter {
+        @Override
+        public long write(byte[] bytes) throws Exception {
+            // TODO(amarcedone): confirm utf-8 is the correct encoding here, as well as loglevel (i).
+            Log.i(TAG_LOGS_FROM_GOBIND, new String(bytes, "UTF-8"));
+
+            // TODO REMOVE ME.
+            if(tv != null){
+                tv.append(TAG_LOGS_FROM_GOBIND + new String(bytes, "UTF-8"));
+            }
+
+            return bytes.length;
+        }
+    }
+
+    private static byte[] resourceToByteArray(Context context, int resourceId) throws IOException {
+        InputStream is = context.getResources().openRawResource(resourceId);
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+        int nRead;
+        // TODO(amarcedone): Buffer size was chosen arbitrarily. Figure out what is appropriate.
+        byte[] data = new byte[16384];
+
+        while ((nRead = is.read(data, 0, data.length)) != -1) {
+            buffer.write(data, 0, nRead);
+        }
+
+        buffer.flush();
+        return buffer.toByteArray();
+    }
+
+}

--- a/keytransparency/src/main/java/com/google/keytransparency/KeyTransparencyException.java
+++ b/keytransparency/src/main/java/com/google/keytransparency/KeyTransparencyException.java
@@ -1,0 +1,10 @@
+package com.google.keytransparency;
+
+/**
+ * A KeyTransparencyException is thrown whenever the go native code throws an Exception.
+ */
+public class KeyTransparencyException extends Throwable {
+    public KeyTransparencyException(Exception e) {
+        super(e);
+    }
+}

--- a/keytransparency/src/main/res/values/strings.xml
+++ b/keytransparency/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">keytransparency</string>
+</resources>


### PR DESCRIPTION
WIP.
Setup bazel WORKSPACE and BUILD files for a keytransparency library.
The library is a light wrapper around the keytransparency go code (compiled through gobind) and (at the moment) only allows to make GetEntry requests.
Depends on https://github.com/google/keytransparency/pull/736
 
